### PR TITLE
fix: preserve FormData boundary when forwarding headers to XHR

### DIFF
--- a/lib/extended-fetch.ts
+++ b/lib/extended-fetch.ts
@@ -158,10 +158,16 @@ export const extendedFetch = (
       xhr.responseType = 'blob'
     }
 
-    // Set Headers
-    request.headers.forEach((value, name) =>
+    // Set Headers.
+    // For FormData bodies, skip Content-Type: `new Request(...)` auto-populated it with the
+    // boundary it computed, but `xhr.send(formData)` will re-encode the body with its own
+    // boundary. Forwarding the Request's Content-Type leaves header and body boundaries out
+    // of sync — servers then fail to parse the multipart payload.
+    const isFormDataBody = initBody instanceof FormData
+    request.headers.forEach((value, name) => {
+      if (isFormDataBody && name.toLowerCase() === 'content-type') return
       xhr.setRequestHeader(name, value)
-    )
+    })
 
     // Handle abort controller signal
     if (request.signal) {

--- a/test/extended-fetch.test.ts
+++ b/test/extended-fetch.test.ts
@@ -26,7 +26,32 @@ describe('Check test env', () => {
 })
 
 describe('Payload', () => {
-  test.todo('can send and receive multipart payload', async () => {
+  test('can send and receive multipart payload', async () => {
+    const form = new FormData()
+    form.append('field', 'value')
+    form.append('file', new Blob(['hello world'], { type: 'text/plain' }), 'hello.txt')
+
+    const result = await extendedFetch(srv.echoBody(), {
+      method: 'POST',
+      body: form,
+    }).then((r) => r.json())
+
+    // The boundary declared in Content-Type must actually appear in the body —
+    // otherwise the server cannot find the parts. This is the regression guard
+    // for the FormData boundary mismatch: previously `new Request(...)` populated
+    // Content-Type with boundary A, then `xhr.send(formData)` re-encoded the body
+    // with boundary B, leaving header and body out of sync.
+    const contentType: string = result['content-type']
+    const match = /boundary=(.+)$/.exec(contentType)
+    expect(match, 'Content-Type must declare a multipart boundary').not.toBeNull()
+    const boundary = match![1]
+
+    expect(result.body).toContain(`--${boundary}`)
+    expect(result.body).toContain('name="field"')
+    expect(result.body).toContain('value')
+    expect(result.body).toContain('name="file"')
+    expect(result.body).toContain('filename="hello.txt"')
+    expect(result.body).toContain('hello world')
   })
 
   test.todo('can send and receive blob payload', async () => {

--- a/test/mock-server.mjs
+++ b/test/mock-server.mjs
@@ -7,7 +7,17 @@ const port = Number(rawPort)
 const requestHandler = (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', `http://${constants.TEST_SRV_HOST}`)
   res.setHeader('Access-Control-Allow-Credentials', true)
-  res.setHeader('Access-Control-Allow-Headers', constants.ALLOWED_HEADERS.join(', '))
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+  res.setHeader(
+    'Access-Control-Allow-Headers',
+    [...constants.ALLOWED_HEADERS, 'Content-Type'].join(', ')
+  )
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204)
+    res.end()
+    return
+  }
 
   try {
     switch (req.url) {
@@ -21,7 +31,21 @@ const requestHandler = (req, res) => {
         res.end(JSON.stringify(req.headers))
         return
 
-      case '/echo-body':
+      case '/echo-body': {
+        const chunks = []
+        req.on('data', (chunk) => chunks.push(chunk))
+        req.on('end', () => {
+          res.writeHead(200, { 'Content-Type': 'application/json' })
+          res.end(
+            JSON.stringify({
+              'content-type': req.headers['content-type'] ?? null,
+              body: Buffer.concat(chunks).toString('utf8'),
+            })
+          )
+        })
+        return
+      }
+
       case '/timeout-error':
       case '/throw-error':
       default:


### PR DESCRIPTION
When a `FormData` body is passed, `new Request(input, init)` auto-populates `Content-Type` with a boundary it computed internally. Forwarding that header to XHR via `setRequestHeader` left the request stuck with that boundary, but `xhr.send(formData)` re-encoded the body with its own boundary — header and body went out of sync, and servers rejected the multipart payload (e.g. Spring returned 400 "Required part 'file' is not present").

Skip the auto-populated `Content-Type` only when the body is `FormData`, so XHR is free to set it itself (with the boundary it actually uses).

Adds:
- `/echo-body` endpoint in `test/mock-server.mjs` returning the request's `content-type` header and raw body, plus OPTIONS/CORS support for POST.
- A regression test that posts a `FormData` payload and asserts the boundary declared in `Content-Type` appears in the body.